### PR TITLE
Make Today/Now methods properties to match DateTime

### DIFF
--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -96,23 +96,29 @@ namespace System
             return DateTime.IsLeapYear(year);
         }
 
-        public static Date Today(TimeZoneInfo timeZone)
+        public static Date TodayAtTimeZone(TimeZoneInfo timeZone)
         {
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             DateTimeOffset localNow = TimeZoneInfo.ConvertTime(utcNow, timeZone);
             return DateFromDateTime(localNow.Date);
         }
 
-        public static Date TodayLocal()
+        public static Date TodayLocal
         {
-            DateTime localNow = DateTime.Now;
-            return DateFromDateTime(localNow);
+            get
+            {
+                DateTime localNow = DateTime.Now;
+                return DateFromDateTime(localNow);
+            }
         }
 
-        public static Date TodayUtc()
+        public static Date TodayUtc
         {
-            DateTime utcNow = DateTime.UtcNow;
-            return DateFromDateTime(utcNow);
+            get
+            {
+                DateTime utcNow = DateTime.UtcNow;
+                return DateFromDateTime(utcNow);
+            }
         }
 
         public Date AddYears(int years)

--- a/System.DateAndTime/TimeOfDay.cs
+++ b/System.DateAndTime/TimeOfDay.cs
@@ -139,23 +139,29 @@ namespace System
             return new DateTime(ticks);
         }
 
-        public static TimeOfDay Now(TimeZoneInfo timeZone)
+        public static TimeOfDay NowAtTimeZone(TimeZoneInfo timeZone)
         {
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             DateTimeOffset localNow = TimeZoneInfo.ConvertTime(utcNow, timeZone);
             return TimeOfDayFromTimeSpan(localNow.TimeOfDay);
         }
 
-        public static TimeOfDay NowLocal()
+        public static TimeOfDay NowLocal
         {
-            var localNow = DateTime.Now;
-            return TimeOfDayFromTimeSpan(localNow.TimeOfDay);
+            get
+            {
+                var localNow = DateTime.Now;
+                return TimeOfDayFromTimeSpan(localNow.TimeOfDay);
+            }
         }
 
-        public static TimeOfDay NowUtc()
+        public static TimeOfDay NowUtc
         {
-            var utcNow = DateTime.UtcNow;
-            return TimeOfDayFromTimeSpan(utcNow.TimeOfDay);
+            get
+            {
+                var utcNow = DateTime.UtcNow;
+                return TimeOfDayFromTimeSpan(utcNow.TimeOfDay);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Since DateTime.Now and DateTime.UtcNow are static properties, Date.TodayUtc, Date.TodayLocal, TimeOfDay.NowUtc, and TimeOfDay.NowLocal should be properties as well. 

Aside: TimeOfDay.NowUtc is backwards in name from DateTime.UtcNow, we should probably normalize this to put Utc and Local first before Today/Now.