### PR TITLE
Use ISO8601 standard for ToString()

### DIFF
--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -179,9 +179,13 @@ namespace System
             return _dayNumber;
         }
 
+        /// <summary>
+        /// Returns an ISO8601 standard string representation of this date.
+        /// </summary>
+        /// <returns>An ISO8601 standard string representation of this date.</returns>
         public override string ToString()
         {
-            return ToDateTimeAtMidnight().ToString("d");
+            return ToDateTimeAtMidnight().ToString("yyyy-MM-dd");
         }
 
         public string ToString(IFormatProvider formatProvider)


### PR DESCRIPTION
Given that ISO8601 is the internationally accepted standard for date representation, and given that other standards that use dates (i.e. HTML5's `<input type="date" />`) use this format, the default parameter-less ToString() should return an ISO8601 date rather than a culture-aware date.