### PR TITLE
Adding ToShortDateString() and sisters to Date and TimeOfDay.

### DIFF
--- a/System.DateAndTime.Tests/DateTests.cs
+++ b/System.DateAndTime.Tests/DateTests.cs
@@ -114,5 +114,13 @@ namespace System.DateAndTime.Tests
                     break;
             }
         }
+
+        [Fact]
+        public void ToIsoString()
+        {
+            var date = new Date(2000, 12, 31);
+            var isoString = date.ToIsoString();
+            Assert.Equal(isoString, "2000-12-31");
+        }
     }
 }

--- a/System.DateAndTime.Tests/DateTests.cs
+++ b/System.DateAndTime.Tests/DateTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.Globalization;
+using Xunit;
 
 namespace System.DateAndTime.Tests
 {
@@ -76,6 +77,42 @@ namespace System.DateAndTime.Tests
 
             DateTime expected = new DateTime(2000, 12, 31, 23, 59, 59);
             Assert.Equal(expected, dt);
+        }
+
+        [Fact]
+        public void ToLongDateString()
+        {
+            var date = new Date(2000, 12, 31);
+            var longDateString = date.ToLongDateString();
+            // ToLongDateString() result depends on the current info. For now, we
+            // only run the assertion if the culture is en GB/US.
+            switch (CultureInfo.CurrentCulture.Name)
+            {
+                case "en-US":
+                    Assert.Equal(longDateString, "Sunday, December 31, 2000");
+                    break;
+                case "en-GB":
+                    Assert.Equal(longDateString, "31 December 2000");
+                    break;
+            }
+        }
+
+        [Fact]
+        public void ToShortDateString()
+        {
+            var date = new Date(2000, 12, 31);
+            var shortDateString = date.ToShortDateString();
+            // ToLongDateString() result depends on the current info. For now, we
+            // only run the assertion if the culture is en GB/US.
+            switch (CultureInfo.CurrentCulture.Name)
+            {
+                case "en-US":
+                    Assert.Equal(shortDateString, "12/31/2000");
+                    break;
+                case "en-GB":
+                    Assert.Equal(shortDateString, "31/12/2000");
+                    break;
+            }
         }
     }
 }

--- a/System.DateAndTime.Tests/TimeOfDayTests.cs
+++ b/System.DateAndTime.Tests/TimeOfDayTests.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.Globalization;
+using Xunit;
 
 namespace System.DateAndTime.Tests
 {
@@ -249,6 +250,34 @@ namespace System.DateAndTime.Tests
             TimeOfDay expected = new TimeOfDay(23, 0);
 
             Assert.Equal(expected, actual);
+        }
+
+        [Fact]
+        public void ToLongDateString()
+        {
+            var time = new TimeOfDay(10, 49, 12, Meridiem.PM);
+            var longTimeString = time.ToLongTimeString();
+            // ToLongTimeString() result depends on the current info. For now, we
+            // only run the assertion if the culture is en GB/US.
+            if (CultureInfo.CurrentCulture.Name == "en-GB" ||
+                CultureInfo.CurrentCulture.Name == "en-US")
+            {
+                Assert.Equal(longTimeString, "10:49:12 PM");
+            }
+        }
+
+        [Fact]
+        public void ToShortDateString()
+        {
+            var time = new TimeOfDay(22, 49);
+            var shortTimeString = time.ToShortTimeString();
+            // ToShortTimeString() result depends on the current info. For now, we
+            // only run the assertion if the culture is en GB/US.
+            if (CultureInfo.CurrentCulture.Name == "en-GB" ||
+                CultureInfo.CurrentCulture.Name == "en-US")
+            {
+                Assert.Equal(shortTimeString, "10:49 PM");
+            }
         }
     }
 }

--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -305,6 +305,12 @@ namespace System
             return obj is Date && Equals((Date)obj);
         }
 
+        /// <summary>
+        /// Returns the hash code of this instance.
+        /// </summary>
+        /// <returns>a 32-bit signed integer hash code.</returns>
+        /// <remarks>The hash code of a <see cref="Date"/> object is the day number, which is
+        /// number of days since January 1, 0001 in the proleptic Gregorian calendar.</remarks>
         public override int GetHashCode()
         {
             return _dayNumber;
@@ -366,7 +372,7 @@ namespace System
         /// current <see cref="Date"/> object.</returns>
         public string ToIsoString()
         {
-            return ToString("yyyy-MM-dd");
+            return ToString("yyyy-MM-dd", CultureInfo.InvariantCulture);
         }
 
         public static Date Parse(string s)

--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -330,6 +330,34 @@ namespace System
             return ToDateTimeAtMidnight().ToString(format, formatProvider);
         }
 
+        /// <summary>
+        /// Converts the value of the current <see cref="Date"/> object to its equivalent
+        /// long date string representation.
+        /// </summary>
+        /// <returns>A string that contains the long date string representation of the
+        /// current <see cref="Date"/> object.</returns>
+        /// <remarks>The value of the current <see cref="Date"/> object is formatted using
+        /// the pattern defined by the <see cref="DateTimeFormatInfo.LongDatePattern" />
+        /// property associated with the current thread culture.</remarks>
+        public string ToLongDateString()
+        {
+            return ToString(CultureInfo.CurrentCulture.DateTimeFormat.LongDatePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="Date"/> object to its equivalent
+        /// short date string representation.
+        /// </summary>
+        /// <returns>A string that contains the short date string representation of the
+        /// current <see cref="Date"/> object.</returns>
+        /// <remarks>The value of the current <see cref="Date"/> object is formatted using
+        /// the pattern defined by the <see cref="DateTimeFormatInfo.ShortDatePattern" />
+        /// property associated with the current thread culture.</remarks>
+        public string ToShortDateString()
+        {
+            return ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
+        }
+
         public static Date Parse(string s)
         {
             DateTime dt = DateTime.Parse(s);

--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -358,6 +358,17 @@ namespace System
             return ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortDatePattern);
         }
 
+        /// <summary>
+        /// Converts the value of the current <see cref="Date"/> object to its equivalent
+        /// ISO standard string representation (ISO-8601), which has the format: yyyy-MM-dd.
+        /// </summary>
+        /// <returns>A string that contains the ISO standard string representation of the
+        /// current <see cref="Date"/> object.</returns>
+        public string ToIsoString()
+        {
+            return ToString("yyyy-MM-dd");
+        }
+
         public static Date Parse(string s)
         {
             DateTime dt = DateTime.Parse(s);

--- a/System.DateAndTime/TimeOfDay.cs
+++ b/System.DateAndTime/TimeOfDay.cs
@@ -328,6 +328,34 @@ namespace System
             return DateTime.MinValue.AddTicks(_ticks).ToString(format, formatProvider);
         }
 
+        /// <summary>
+        /// Converts the value of the current <see cref="TimeOfDay"/> object to its equivalent
+        /// long time string representation.
+        /// </summary>
+        /// <returns>A string that contains the long time string representation of the
+        /// current <see cref="TimeOfDay"/> object.</returns>
+        /// <remarks>The value of the current <see cref="TimeOfDay"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.LongTimePattern" />
+        /// property associated with the current thread culture.</remarks>
+        public string ToLongTimeString()
+        {
+            return ToString(CultureInfo.CurrentCulture.DateTimeFormat.LongTimePattern);
+        }
+
+        /// <summary>
+        /// Converts the value of the current <see cref="TimeOfDay"/> object to its equivalent
+        /// short time string representation.
+        /// </summary>
+        /// <returns>A string that contains the short time string representation of the
+        /// current <see cref="TimeOfDay"/> object.</returns>
+        /// <remarks>The value of the current <see cref="TimeOfDay"/> object is formatted
+        /// using the pattern defined by the <see cref="DateTimeFormatInfo.ShortTimePattern" />
+        /// property associated with the current thread culture.</remarks>
+        public string ToShortTimeString()
+        {
+            return ToString(CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern);
+        }
+
         public static TimeOfDay Parse(string s)
         {
             DateTime dt = DateTime.Parse(s, null, DateTimeStyles.NoCurrentDateDefault);


### PR DESCRIPTION
Added the following convenience methods to Date and TimeOfDay:
- Date.ToShortDateString()
- Date.ToLongDateString()
- TimeOfDay.ToShortTimeString()
- TimeOfDay.ToLongDateString()

#16