### PR TITLE
Update methods and properties for getting current date and time

### DIFF
--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -212,7 +212,7 @@ namespace System
             return days[month] - days[month - 1];
         }
 
-        public static Date Today(TimeZoneInfo timeZone)
+        public static Date TodayInTimeZone(TimeZoneInfo timeZone)
         {
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             DateTimeOffset localNow = TimeZoneInfo.ConvertTime(utcNow, timeZone);

--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -219,16 +219,22 @@ namespace System
             return DateFromDateTime(localNow.Date);
         }
 
-        public static Date TodayLocal()
+        public static Date Today
         {
-            DateTime localNow = DateTime.Now;
-            return DateFromDateTime(localNow);
+            get
+            {
+                DateTime localNow = DateTime.Now;
+                return DateFromDateTime(localNow);
+            }
         }
 
-        public static Date TodayUtc()
+        public static Date UtcToday
         {
-            DateTime utcNow = DateTime.UtcNow;
-            return DateFromDateTime(utcNow);
+            get
+            {
+                DateTime utcNow = DateTime.UtcNow;
+                return DateFromDateTime(utcNow);
+            }
         }
 
         public Date AddYears(int years)

--- a/System.DateAndTime/DateTimeEx.cs
+++ b/System.DateAndTime/DateTimeEx.cs
@@ -14,11 +14,9 @@
         {
             return new TimeOfDay(dateTime.TimeOfDay.Ticks);
         }
-
-
-
-
-        public static DateTime Now(TimeZoneInfo timeZone)
+        
+        // TODO: Propose placing this method directly in the System.DateTime struct
+        public static DateTime NowInTimeZone(TimeZoneInfo timeZone)
         {
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             return TimeZoneInfo.ConvertTime(utcNow, timeZone).DateTime;

--- a/System.DateAndTime/DateTimeEx.cs
+++ b/System.DateAndTime/DateTimeEx.cs
@@ -21,15 +21,5 @@
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             return TimeZoneInfo.ConvertTime(utcNow, timeZone).DateTime;
         }
-
-        public static DateTime NowLocal()
-        {
-            return DateTime.Now;
-        }
-
-        public static DateTime NowUtc()
-        {
-            return DateTime.UtcNow;
-        }
     }
 }

--- a/System.DateAndTime/DateTimeOffsetEx.cs
+++ b/System.DateAndTime/DateTimeOffsetEx.cs
@@ -21,15 +21,5 @@
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             return TimeZoneInfo.ConvertTime(utcNow, timeZone);
         }
-
-        public static DateTimeOffset NowLocal()
-        {
-            return DateTimeOffset.Now;
-        }
-
-        public static DateTimeOffset NowUtc()
-        {
-            return DateTimeOffset.UtcNow;
-        }
     }
 }

--- a/System.DateAndTime/DateTimeOffsetEx.cs
+++ b/System.DateAndTime/DateTimeOffsetEx.cs
@@ -15,9 +15,8 @@
             return new TimeOfDay(dateTimeOffset.TimeOfDay.Ticks);
         }
 
-
-
-        public static DateTimeOffset Now(TimeZoneInfo timeZone)
+        // TODO: Propose placing this method directly in the System.DateTimeOffset struct
+        public static DateTimeOffset NowInTimeZone(TimeZoneInfo timeZone)
         {
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             return TimeZoneInfo.ConvertTime(utcNow, timeZone);

--- a/System.DateAndTime/System.DateAndTime.csproj
+++ b/System.DateAndTime/System.DateAndTime.csproj
@@ -43,6 +43,7 @@
     <Compile Include="Meridiem.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimeOfDay.cs" />
+    <Compile Include="TimeZoneInfoEx.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/System.DateAndTime/TimeOfDay.cs
+++ b/System.DateAndTime/TimeOfDay.cs
@@ -192,7 +192,7 @@ namespace System
             return new DateTime(ticks);
         }
 
-        public static TimeOfDay Now(TimeZoneInfo timeZone)
+        public static TimeOfDay NowInTimeZone(TimeZoneInfo timeZone)
         {
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             DateTimeOffset localNow = TimeZoneInfo.ConvertTime(utcNow, timeZone);

--- a/System.DateAndTime/TimeOfDay.cs
+++ b/System.DateAndTime/TimeOfDay.cs
@@ -199,16 +199,22 @@ namespace System
             return TimeOfDayFromTimeSpan(localNow.TimeOfDay);
         }
 
-        public static TimeOfDay NowLocal()
+        public static TimeOfDay Now
         {
-            var localNow = DateTime.Now;
-            return TimeOfDayFromTimeSpan(localNow.TimeOfDay);
+            get
+            {
+                DateTime localNow = DateTime.Now;
+                return TimeOfDayFromTimeSpan(localNow.TimeOfDay);
+            }
         }
 
-        public static TimeOfDay NowUtc()
+        public static TimeOfDay UtcNow
         {
-            var utcNow = DateTime.UtcNow;
-            return TimeOfDayFromTimeSpan(utcNow.TimeOfDay);
+            get
+            {
+                DateTime utcNow = DateTime.UtcNow;
+                return TimeOfDayFromTimeSpan(utcNow.TimeOfDay);
+            }
         }
 
         /// <summary>

--- a/System.DateAndTime/TimeZoneInfoEx.cs
+++ b/System.DateAndTime/TimeZoneInfoEx.cs
@@ -1,0 +1,25 @@
+﻿namespace System
+{
+    public static class TimeZoneInfoEx
+    {
+        public static DateTimeOffset GetCurrentDateTimeOffset(this TimeZoneInfo timeZoneInfo)
+        {
+            return DateTimeOffsetEx.NowInTimeZone(timeZoneInfo);
+        }
+
+        public static DateTime GetCurrentDateTime(this TimeZoneInfo timeZoneInfo)
+        {
+            return DateTimeEx.NowInTimeZone(timeZoneInfo);
+        }
+        
+        public static Date GetCurrentDate(this TimeZoneInfo timeZoneInfo)
+        {
+            return Date.TodayInTimeZone(timeZoneInfo);
+        }
+
+        public static TimeOfDay GetCurrentTime(this TimeZoneInfo timeZoneInfo)
+        {
+            return TimeOfDay.NowInTimeZone(timeZoneInfo);
+        }
+    }
+}


### PR DESCRIPTION
Per #15, switched to conform to the same property-centric conventions of the existing data types.

- `TimeOfDay.Now`
- `TimeOfDay.UtcNow`
- `Date.Today`
- `Date.UtcToday`

Also added some time zone specific methods:
- `TimeOfDay.NowInTimeZone(TimeZoneInfo)`
- `Date.TodayInTimeZone(TimeZoneInfo)`
- `DateTimeOffsetEx.NowInTimeZone(TimeZoneInfo)`
- `DateTimeEx.NowInTimeZone(TimeZoneInfo)`

And some extension methods from `TimeZoneInfo`:
- `TimeZoneInfo.GetCurrentDateTimeOffset()`
- `TimeZoneInfo.GetCurrentDateTime()`
- `TimeZoneInfo.GetCurrentDate()`
- `TimeZoneInfo.GetCurrentTime()`