### PR TITLE
Add support for Calendars

### DIFF
--- a/System.DateAndTime.Tests/DateCalendarTests.cs
+++ b/System.DateAndTime.Tests/DateCalendarTests.cs
@@ -1,0 +1,16 @@
+﻿using System.Globalization;
+using Xunit;
+
+namespace System.DateAndTime.Tests
+{
+    public class DateCalendarTests
+    {
+        [Fact]
+        public void CanCreateDateWithCalendar()
+        {
+            var actual = new Date(1436, 3, 10, new UmAlQuraCalendar());
+            var expected = new Date(2015, 1, 1);
+            Assert.Equal(expected, actual);
+        }
+    }
+}

--- a/System.DateAndTime.Tests/DateCalendarTests.cs
+++ b/System.DateAndTime.Tests/DateCalendarTests.cs
@@ -12,5 +12,20 @@ namespace System.DateAndTime.Tests
             var expected = new Date(2015, 1, 1);
             Assert.Equal(expected, actual);
         }
+
+        [Fact]
+        public void CanUseDateInCalendar()
+        {
+            var dt = new Date(2015, 1, 1);
+
+            var calendar = new UmAlQuraCalendar();
+            var year = calendar.GetYear(dt);
+            var month = calendar.GetMonth(dt);
+            var day = calendar.GetDayOfMonth(dt);
+            
+            Assert.Equal(1436, year);
+            Assert.Equal(3, month);
+            Assert.Equal(10, day);
+        }
     }
 }

--- a/System.DateAndTime.Tests/System.DateAndTime.Tests.csproj
+++ b/System.DateAndTime.Tests/System.DateAndTime.Tests.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DateCalendarTests.cs" />
     <Compile Include="DateTests.cs" />
     <Compile Include="DateTimeTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -75,6 +75,12 @@ namespace System
             _dayNumber = DateToDayNumber(year, month, day);
         }
 
+        public Date(int year, int month, int day, Calendar calendar)
+        {
+            DateTime dt = calendar.ToDateTime(year, month, day, 0, 0, 0, 0);
+            _dayNumber = (int)(dt.Ticks / TimeSpan.TicksPerDay);
+        }
+
         public Date(int year, int dayOfYear)
         {
             if (dayOfYear < 1 || dayOfYear > (IsLeapYear(year) ? 366 : 365))

--- a/System.DateAndTime/Date.cs
+++ b/System.DateAndTime/Date.cs
@@ -500,6 +500,14 @@ namespace System
             return DateFromDateTime(dateTime);
         }
 
+        public static implicit operator DateTime(Date date)
+        {
+            // This is useful such that Date types can be used in methods that typically expect a DateTime.
+            // For example, Calendar.GetYear(DateTime) and similar methods.
+
+            return date.ToDateTimeAtMidnight();
+        }
+
         private static Date DateFromDateTime(DateTime dateTime)
         {
             return new Date((int)(dateTime.Date.Ticks / TimeSpan.TicksPerDay));


### PR DESCRIPTION
Per #7 - Adding a constructor that will accept a `System.Gloablization.Calendar`.

Also added an implicit cast operator such that a `Date` can be passed to existing methods on a `Calendar` instance, and in other similar scenarios where the time portion of a `DateTime` is irrelevant.