### PR TITLE
Add tz-aware add/subtract methods on DateTimeOffset

### DIFF
--- a/System.DateAndTime.Tests/DateTimeOffsetTests.cs
+++ b/System.DateAndTime.Tests/DateTimeOffsetTests.cs
@@ -1,0 +1,139 @@
+﻿using Xunit;
+
+namespace System.DateAndTime.Tests
+{
+    public class DateTimeOffsetTests
+    {
+        [Fact]
+        public void CanAddYearsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2014, 3, 9, 0, 0, 0, TimeSpan.FromHours(-8));
+            var result = dto.AddYears(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddMonthsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 2, 9, 0, 0, 0, TimeSpan.FromHours(-8));
+            var result = dto.AddMonths(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 8, 0, 0, 0, TimeSpan.FromHours(-8));
+            var result = dto.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition_LandInGap()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 7, 2, 30, 0, TimeSpan.FromHours(-8));
+            var result = dto.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 30, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition_LandInOverlap()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 10, 31, 1, 30, 0, TimeSpan.FromHours(-7));
+            var result = dto.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 11, 1, 1, 30, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition_StartWithMismatchedOffset()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 8, 4, 0, 0, TimeSpan.FromHours(-4));
+            var result = dto.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddHoursAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 8, 1, 0, 0, TimeSpan.FromHours(-8));
+            var result = dto.AddHours(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddMinutesAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 8, 1, 59, 0, TimeSpan.FromHours(-8));
+            var result = dto.AddMinutes(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddSecondsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 8, 1, 59, 59, TimeSpan.FromHours(-8));
+            var result = dto.AddSeconds(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddMillisecondsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 8, 1, 59, 59, 999, TimeSpan.FromHours(-8));
+            var result = dto.AddMilliseconds(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddTicksAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dto = new DateTimeOffset(2015, 3, 8, 1, 59, 59, 999, TimeSpan.FromHours(-8)).AddTicks(9999);
+            var result = dto.AddTicks(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+    }
+}

--- a/System.DateAndTime.Tests/DateTimeTests.cs
+++ b/System.DateAndTime.Tests/DateTimeTests.cs
@@ -15,5 +15,150 @@ namespace System.DateAndTime.Tests
         {
             TimeOfDay time = DateTime.Now.TimeOfDay;
         }
+
+        [Fact]
+        public void CanAddYearsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2014, 3, 9, 0, 0, 0);
+            var result = dt.AddYears(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddMonthsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 2, 9, 0, 0, 0);
+            var result = dt.AddMonths(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 0, 0, 0);
+            var result = dt.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition_LandInGap()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 7, 2, 30, 0);
+            var result = dt.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 30, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition_LandInOverlap()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 10, 31, 1, 30, 0);
+            var result = dt.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 11, 1, 1, 30, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddDaysAcrossDstTransition_StartWithMismatchedKind()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 8, 0, 0, DateTimeKind.Utc);
+            var result = dt.AddDays(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 9, 0, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+
+        [Fact]
+        public void CanAddHoursAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 1, 0, 0);
+            var result = dt.AddHours(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddHoursAcrossDstTransition_StartWithMismatchedKind()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 9, 0, 0, DateTimeKind.Utc);
+            var result = dt.AddHours(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddMinutesAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 1, 59, 0);
+            var result = dt.AddMinutes(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddSecondsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 1, 59, 59);
+            var result = dt.AddSeconds(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddMillisecondsAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 1, 59, 59, 999);
+            var result = dt.AddMilliseconds(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
+
+        [Fact]
+        public void CanAddTicksAcrossDstTransition()
+        {
+            var tz = TimeZoneInfo.FindSystemTimeZoneById("Pacific Standard Time");
+            var dt = new DateTime(2015, 3, 8, 1, 59, 59, 999).AddTicks(9999);
+            var result = dt.AddTicks(1, tz);
+
+            var expected = new DateTimeOffset(2015, 3, 8, 3, 0, 0, TimeSpan.FromHours(-7));
+            Assert.Equal(expected, result);
+            Assert.Equal(expected.Offset, result.Offset);
+        }
     }
 }

--- a/System.DateAndTime.Tests/System.DateAndTime.Tests.csproj
+++ b/System.DateAndTime.Tests/System.DateAndTime.Tests.csproj
@@ -57,6 +57,7 @@
     <Compile Include="DateFormattingTests.cs" />
     <Compile Include="DateMathTests.cs" />
     <Compile Include="DateMiscTests.cs" />
+    <Compile Include="DateTimeOffsetTests.cs" />
     <Compile Include="TimeOfDayComparisonTests.cs" />
     <Compile Include="TimeOfDayConstructionTests.cs" />
     <Compile Include="TimeOfDayMathTests.cs" />

--- a/System.DateAndTime/DateTimeEx.cs
+++ b/System.DateAndTime/DateTimeEx.cs
@@ -39,5 +39,119 @@
             DateTime utcNow = DateTime.UtcNow;
             return TimeZoneInfo.ConvertTime(utcNow, timeZoneInfo);
         }
+
+        public static DateTimeOffset AddYears(this DateTime dateTime, int years, TimeZoneInfo timeZone)
+        {
+            return AddByDate(dateTime, dt => dt.AddYears(years), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddYears(this DateTime dateTime, int years, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return AddByDate(dateTime, dt => dt.AddYears(years), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddMonths(this DateTime dateTime, int months, TimeZoneInfo timeZone)
+        {
+            return AddByDate(dateTime, dt => dt.AddMonths(months), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddMonths(this DateTime dateTime, int months, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return AddByDate(dateTime, dt => dt.AddMonths(months), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddDays(this DateTime dateTime, int days, TimeZoneInfo timeZone)
+        {
+            return AddByDate(dateTime, dt => dt.AddDays(days), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddDays(this DateTime dateTime, int days, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return AddByDate(dateTime, dt => dt.AddDays(days), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddHours(this DateTime dateTime, double hours, TimeZoneInfo timeZone)
+        {
+            return dateTime.Add(TimeSpan.FromHours(hours), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddHours(this DateTime dateTime, double hours, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return dateTime.Add(TimeSpan.FromHours(hours), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddMinutes(this DateTime dateTime, double minutes, TimeZoneInfo timeZone)
+        {
+            return dateTime.Add(TimeSpan.FromMinutes(minutes), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddMinutes(this DateTime dateTime, double minutes, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return dateTime.Add(TimeSpan.FromMinutes(minutes), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddSeconds(this DateTime dateTime, double seconds, TimeZoneInfo timeZone)
+        {
+            return dateTime.Add(TimeSpan.FromSeconds(seconds), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddSeconds(this DateTime dateTime, double seconds, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return dateTime.Add(TimeSpan.FromSeconds(seconds), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddMilliseconds(this DateTime dateTime, double milliseconds, TimeZoneInfo timeZone)
+        {
+            return dateTime.Add(TimeSpan.FromMilliseconds(milliseconds), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddMilliseconds(this DateTime dateTime, double milliseconds, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return dateTime.Add(TimeSpan.FromMilliseconds(milliseconds), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddTicks(this DateTime dateTime, long ticks, TimeZoneInfo timeZone)
+        {
+            return dateTime.Add(TimeSpan.FromTicks(ticks), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddTicks(this DateTime dateTime, long ticks, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return dateTime.Add(TimeSpan.FromTicks(ticks), timeZone, resolver);
+        }
+
+        public static DateTimeOffset Add(this DateTime dateTime, TimeSpan timeSpan, TimeZoneInfo timeZone)
+        {
+            return dateTime.Add(timeSpan, timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset Subtract(this DateTime dateTime, TimeSpan timeSpan, TimeZoneInfo timeZone)
+        {
+            return dateTime.Add(timeSpan.Negate(), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset Subtract(this DateTime dateTime, TimeSpan timeSpan, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return dateTime.Add(timeSpan.Negate(), timeZone, resolver);
+        }
+
+        public static DateTimeOffset Add(this DateTime dateTime, TimeSpan timeSpan, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            var utc = dateTime.Kind == DateTimeKind.Unspecified
+                ? resolver.Invoke(dateTime, timeZone).UtcDateTime
+                : dateTime.ToUniversalTime();
+
+            var dt = utc.Add(timeSpan);
+            return TimeZoneInfo.ConvertTime(dt, timeZone);
+        }
+        
+        private static DateTimeOffset AddByDate(DateTime dateTime, Func<DateTime, DateTime> operation, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            if (dateTime.Kind != DateTimeKind.Unspecified)
+                dateTime = TimeZoneInfo.ConvertTime(dateTime, timeZone);
+
+            var dt = operation.Invoke(dateTime);
+            return resolver.Invoke(dt, timeZone);
+        }
     }
 }

--- a/System.DateAndTime/DateTimeOffsetEx.cs
+++ b/System.DateAndTime/DateTimeOffsetEx.cs
@@ -40,5 +40,78 @@
             DateTimeOffset utcNow = DateTimeOffset.UtcNow;
             return TimeZoneInfo.ConvertTime(utcNow, timeZoneInfo);
         }
+
+        public static DateTimeOffset AddYears(this DateTimeOffset dateTimeOffset, int years, TimeZoneInfo timeZone)
+        {
+            return AddByDate(dateTimeOffset, dt => dt.AddYears(years), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddYears(this DateTimeOffset dateTimeOffset, int years, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return AddByDate(dateTimeOffset, dt => dt.AddYears(years), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddMonths(this DateTimeOffset dateTimeOffset, int months, TimeZoneInfo timeZone)
+        {
+            return AddByDate(dateTimeOffset, dt => dt.AddMonths(months), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddMonths(this DateTimeOffset dateTimeOffset, int months, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return AddByDate(dateTimeOffset, dt => dt.AddMonths(months), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddDays(this DateTimeOffset dateTimeOffset, int days, TimeZoneInfo timeZone)
+        {
+            return AddByDate(dateTimeOffset, dt => dt.AddDays(days), timeZone, TimeZoneOffsetResolvers.Default);
+        }
+
+        public static DateTimeOffset AddDays(this DateTimeOffset dateTimeOffset, int days, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            return AddByDate(dateTimeOffset, dt => dt.AddDays(days), timeZone, resolver);
+        }
+
+        public static DateTimeOffset AddHours(this DateTimeOffset dateTimeOffset, double hours, TimeZoneInfo timeZone)
+        {
+            return dateTimeOffset.Add(TimeSpan.FromHours(hours), timeZone);
+        }
+
+        public static DateTimeOffset AddMinutes(this DateTimeOffset dateTimeOffset, double minutes, TimeZoneInfo timeZone)
+        {
+            return dateTimeOffset.Add(TimeSpan.FromMinutes(minutes), timeZone);
+        }
+
+        public static DateTimeOffset AddSeconds(this DateTimeOffset dateTimeOffset, double seconds, TimeZoneInfo timeZone)
+        {
+            return dateTimeOffset.Add(TimeSpan.FromSeconds(seconds), timeZone);
+        }
+
+        public static DateTimeOffset AddMilliseconds(this DateTimeOffset dateTimeOffset, double milliseconds, TimeZoneInfo timeZone)
+        {
+            return dateTimeOffset.Add(TimeSpan.FromMilliseconds(milliseconds), timeZone);
+        }
+
+        public static DateTimeOffset AddTicks(this DateTimeOffset dateTimeOffset, long ticks, TimeZoneInfo timeZone)
+        {
+            return dateTimeOffset.Add(TimeSpan.FromTicks(ticks), timeZone);
+        }
+
+        public static DateTimeOffset Subtract(this DateTimeOffset dateTimeOffset, TimeSpan timeSpan, TimeZoneInfo timeZone)
+        {
+            return dateTimeOffset.Add(timeSpan.Negate(), timeZone);
+        }
+
+        public static DateTimeOffset Add(this DateTimeOffset dateTimeOffset, TimeSpan timeSpan, TimeZoneInfo timeZone)
+        {
+            var t = dateTimeOffset.Add(timeSpan);
+            return TimeZoneInfo.ConvertTime(t, timeZone);
+        }
+        
+        private static DateTimeOffset AddByDate(DateTimeOffset dateTimeOffset, Func<DateTime, DateTime> operation, TimeZoneInfo timeZone, TimeZoneOffsetResolver resolver)
+        {
+            var dto = TimeZoneInfo.ConvertTime(dateTimeOffset, timeZone);
+            var dt = operation.Invoke(dto.DateTime);
+            return resolver.Invoke(dt, timeZone);
+        }
     }
 }

--- a/System.DateAndTime/System.DateAndTime.csproj
+++ b/System.DateAndTime/System.DateAndTime.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TimeOfDay.cs" />
     <Compile Include="TimeZoneInfoEx.cs" />
+    <Compile Include="TimeZoneOffsetResolvers.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 

--- a/System.DateAndTime/TimeZoneOffsetResolvers.cs
+++ b/System.DateAndTime/TimeZoneOffsetResolvers.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace System
+{
+    public delegate DateTimeOffset TimeZoneOffsetResolver(DateTime dateTime, TimeZoneInfo timeZone);
+
+    public static class TimeZoneOffsetResolvers
+    {
+        public static DateTimeOffset Default(DateTime dt, TimeZoneInfo timeZone)
+        {
+            if (timeZone.IsAmbiguousTime(dt))
+            {
+                var earlierOffset = timeZone.GetUtcOffset(dt.AddDays(-1));
+                return new DateTimeOffset(dt, earlierOffset);
+            }
+
+            if (timeZone.IsInvalidTime(dt))
+            {
+                var earlierOffset = timeZone.GetUtcOffset(dt.AddDays(-1));
+                var laterOffset = timeZone.GetUtcOffset(dt.AddDays(1));
+                var transitionGap = laterOffset - earlierOffset;
+                return new DateTimeOffset(dt.Add(transitionGap), laterOffset);
+            }
+
+            return new DateTimeOffset(dt, timeZone.GetUtcOffset(dt));
+        }
+
+        // TODO: include other kinds of resolvers
+    }
+}


### PR DESCRIPTION
Per #34, adds methods for adding and subtracting time in a timezone-aware manner, such that when a daylight saving time transition is encountered, the resulting value is "correct" for the time zone supplied.
